### PR TITLE
Prepare sexp deprecations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,9 @@
 {
     "cSpell.words": [
         "janestreet",
+        "ocamlmig",
         "odoc",
-        "opam"
+        "opam",
+        "reraise"
     ]
 }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,17 @@
+## 0.0.12 (unreleased)
+
+### Added
+
+### Changed
+
+- Rename `Err.pp_of_sexp` to `Err.sexp` to make it shorter (@mbarbin).
+
+### Deprecated
+
+- Prepare the deprecation of sexp based err constructors (@mbarbin).
+
+### Fixed
+
 ## 0.0.11 (2025-04-25)
 
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,11 +4,11 @@
 
 ### Changed
 
-- Rename `Err.pp_of_sexp` to `Err.sexp` to make it shorter (@mbarbin).
+- Rename `Err.pp_of_sexp` to `Err.sexp` to make it shorter (#4, @mbarbin).
 
 ### Deprecated
 
-- Prepare the deprecation of sexp based err constructors (@mbarbin).
+- Prepare the deprecation of sexp based err constructors (#4, @mbarbin).
 
 ### Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 ## 0.0.12 (unreleased)
 
+This releases prepares the deprecation of a few functions and contains `ocamlmig` annotations to help users with the migration.
+
+To automatically apply the migration changes, first upgrade your `pplumbing` dependency and re-build your project. Then run the following command, from the root of your project:
+
+```sh
+$ ocamlmig migrate
+```
+
 ### Added
 
 ### Changed

--- a/lib/err/src/err.ml
+++ b/lib/err/src/err.ml
@@ -377,15 +377,15 @@ module Private = struct
 end
 
 let create_s ?loc ?hints ?exit_code desc s =
-  create ?loc ?hints ?exit_code [ Pp.text desc; sexp s ]
+  create ?loc ?hints ?exit_code [ Pp.text desc; sexp s ] [@coverage off]
 ;;
 
 let raise_s ?loc ?hints ?exit_code desc s =
-  raise ?loc ?hints ?exit_code [ Pp.text desc; sexp s ]
+  raise ?loc ?hints ?exit_code [ Pp.text desc; sexp s ] [@coverage off]
 ;;
 
 let reraise_s bt e ?loc ?hints ?exit_code desc s =
-  reraise bt e ?loc ?hints ?exit_code [ Pp.text desc; sexp s ]
+  reraise bt e ?loc ?hints ?exit_code [ Pp.text desc; sexp s ] [@coverage off]
 ;;
 
 let pp_of_sexp = sexp

--- a/lib/err/src/err.ml
+++ b/lib/err/src/err.ml
@@ -87,7 +87,7 @@ let ok_exn = function
 
 let did_you_mean = Stdune.User_message.did_you_mean
 
-let pp_of_sexp sexp =
+let sexp sexp =
   let rec aux sexp =
     match (sexp : Sexplib0.Sexp.t) with
     | Atom s -> Pp.verbatim s
@@ -98,18 +98,6 @@ let pp_of_sexp sexp =
   | List (Atom atom :: sexps) ->
     Pp.O.(Pp.verbatim atom ++ Pp.space ++ Pp.concat_map sexps ~f:aux)
   | sexp -> aux sexp
-;;
-
-let create_s ?loc ?hints ?exit_code desc sexp =
-  create ?loc ?hints ?exit_code [ Pp.text desc; pp_of_sexp sexp ]
-;;
-
-let raise_s ?loc ?hints ?exit_code desc sexp =
-  raise ?loc ?hints ?exit_code [ Pp.text desc; pp_of_sexp sexp ]
-;;
-
-let reraise_s bt e ?loc ?hints ?exit_code desc sexp =
-  reraise bt e ?loc ?hints ?exit_code [ Pp.text desc; pp_of_sexp sexp ]
 ;;
 
 module Color_mode = struct
@@ -387,3 +375,17 @@ module Private = struct
     ()
   ;;
 end
+
+let create_s ?loc ?hints ?exit_code desc s =
+  create ?loc ?hints ?exit_code [ Pp.text desc; sexp s ]
+;;
+
+let raise_s ?loc ?hints ?exit_code desc s =
+  raise ?loc ?hints ?exit_code [ Pp.text desc; sexp s ]
+;;
+
+let reraise_s bt e ?loc ?hints ?exit_code desc s =
+  reraise bt e ?loc ?hints ?exit_code [ Pp.text desc; sexp s ]
+;;
+
+let pp_of_sexp = sexp

--- a/lib/err/src/err.mli
+++ b/lib/err/src/err.mli
@@ -366,9 +366,8 @@ end
 
 (** {1 Deprecated}
 
-    This part of the API is, or will be soon, deprecated. We have
-    added [ocamlmig] annotations to help with migrating existing
-    code. *)
+    This part of the API is, or will be soon, deprecated. We have added
+    [ocamlmig] annotations to help with migrating existing code. *)
 
 (** This is deprecated - use [Err.create] instead. *)
 val create_s

--- a/lib/err/src/err.mli
+++ b/lib/err/src/err.mli
@@ -380,7 +380,11 @@ val create_s
 [@@migrate
   { repl =
       (fun ?loc ?hints ?exit_code msg sexp ->
-        Rel.create ?loc ?hints ?exit_code [ Pp.text msg; Rel.sexp sexp ])
+        Rel.create
+          ?loc
+          ?hints
+          ?exit_code
+          [ (Pp.text msg [@commutes]); (Rel.sexp sexp [@commutes]) ])
   ; libraries = [ "pp" ]
   }]
 
@@ -395,7 +399,11 @@ val raise_s
 [@@migrate
   { repl =
       (fun ?loc ?hints ?exit_code msg sexp ->
-        Rel.raise ?loc ?hints ?exit_code [ Pp.text msg; Rel.sexp sexp ])
+        Rel.raise
+          ?loc
+          ?hints
+          ?exit_code
+          [ (Pp.text msg [@commutes]); (Rel.sexp sexp [@commutes]) ])
   ; libraries = [ "pp" ]
   }]
 
@@ -412,7 +420,13 @@ val reraise_s
 [@@migrate
   { repl =
       (fun bt e ?loc ?hints ?exit_code msg sexp ->
-        Rel.reraise bt e ?loc ?hints ?exit_code [ Pp.text msg; Rel.sexp sexp ])
+        Rel.reraise
+          bt
+          e
+          ?loc
+          ?hints
+          ?exit_code
+          [ (Pp.text msg [@commutes]); (Rel.sexp sexp [@commutes]) ])
   ; libraries = [ "pp" ]
   }]
 

--- a/lib/err/test/dune
+++ b/lib/err/test/dune
@@ -20,6 +20,7 @@
   fpath
   loc
   logs
+  pp
   pplumbing.log-cli
   stdune)
  (instrumentation

--- a/lib/err/test/test__err.ml
+++ b/lib/err/test/test__err.ml
@@ -172,11 +172,12 @@ let%expect_test "ok_exn" =
 
 let%expect_test "create_s" =
   let err =
-    Err.create_s
+    Err.create
       ~loc:(Loc.of_file ~path:(Fpath.v "path/to/my-file.txt"))
       ~hints:(Err.did_you_mean "bah" ~candidates:[ "bar"; "foo" ])
-      "The summary of the error"
-      [%sexp { x = 42; y = Some "msg"; var = "bah" }]
+      [ Pp.text "The summary of the error"
+      ; Err.sexp [%sexp { x = 42; y = Some "msg"; var = "bah" }]
+      ]
   in
   Err.For_test.protect (fun () -> raise (Err.E err));
   [%expect
@@ -192,11 +193,10 @@ let%expect_test "create_s" =
 
 let%expect_test "raise_s" =
   Err.For_test.protect (fun () ->
-    Err.raise_s
+    Err.raise
       ~loc:(Loc.of_file ~path:(Fpath.v "path/to/my-file.txt"))
       ~hints:(Err.did_you_mean "bah" ~candidates:[ "bar"; "foo" ])
-      "Hello Raise"
-      [%sexp { hello = 42 }]);
+      [ Pp.text "Hello Raise"; Err.sexp [%sexp { hello = 42 }] ]);
   [%expect
     {|
     File "path/to/my-file.txt", line 1, characters 0-0:
@@ -211,21 +211,19 @@ let%expect_test "raise_s" =
 let%expect_test "reraise_s" =
   Err.For_test.protect (fun () ->
     match
-      Err.raise_s
+      Err.raise
         ~loc:(Loc.of_file ~path:(Fpath.v "path/to/my-file.txt"))
         ~hints:(Err.did_you_mean "bah" ~candidates:[ "bar"; "foo" ])
-        "Hello Raise"
-        [%sexp { hello = 42 }]
+        [ Pp.text "Hello Raise"; Err.sexp [%sexp { hello = 42 }] ]
     with
     | _ -> assert false
     | exception Err.E e ->
       let bt = Stdlib.Printexc.get_raw_backtrace () in
-      Err.reraise_s
+      Err.reraise
         bt
         e
         ~loc:(Loc.of_file ~path:(Fpath.v "path/to/other-file.txt"))
-        "Re raised with context"
-        [%sexp { x = 42 }]);
+        [ Pp.text "Re raised with context"; Err.sexp [%sexp { x = 42 }] ]);
   [%expect
     {|
     File "path/to/my-file.txt", line 1, characters 0-0:

--- a/lib/err/test/test__pp_of_sexp.ml
+++ b/lib/err/test/test__pp_of_sexp.ml
@@ -1,5 +1,5 @@
 let%expect_test "pp_of_sexp" =
-  let test sexp = Err.For_test.protect (fun () -> Err.raise [ Err.pp_of_sexp sexp ]) in
+  let test sexp = Err.For_test.protect (fun () -> Err.raise [ Err.sexp sexp ]) in
   test [%sexp ()];
   [%expect
     {|


### PR DESCRIPTION
This PR prepares the deprecation of sexp based err constructors, to be replaced by pp based equivalent.

We don't flag the functions as deprecated just yet, as we plan on leaving at least 1 release for advanced clients to update automatically thanks to `ocamlmig` annotations.
