### PR TITLE
Improve sexp handling and add support for context

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,13 @@ To automatically apply the migration changes, first upgrade your `pplumbing` dep
 
 ### Added
 
+- Add concept of error "context" that can be augmented (#6, @mbarbin).
+- Better support and rendering of errors built with `Err.sexp` (#6, @mbarbin).
+
 ### Changed
 
+- Tweak some details in format of `Err.sexp_of_t` (#6, @mbarbin).
+- Do not include exit code in `Err.sexp_of_t` by default (#6, @mbarbin).
 - Rename `Err.pp_of_sexp` to `Err.sexp` to make it shorter (#4, @mbarbin).
 
 ### Deprecated
@@ -18,6 +23,7 @@ To automatically apply the migration changes, first upgrade your `pplumbing` dep
 
 ### Removed
 
+- Replaced `Err.append` by `Err.add_context` (#6, @mbarbin).
 - Removed `Stdune.User_message.t -> Err.t` helper (#5, @mbarbin).
 
 ## 0.0.11 (2025-04-25)

--- a/lib/err/src/dune
+++ b/lib/err/src/dune
@@ -2,7 +2,7 @@
  (name err)
  (public_name pplumbing.err)
  (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a)
- (libraries loc pp pp_tty sexplib0 stdune)
+ (libraries loc parsexp pp pp_tty sexplib0 stdune)
  (instrumentation
   (backend bisect_ppx))
  (lint

--- a/lib/err/src/err.ml
+++ b/lib/err/src/err.ml
@@ -7,11 +7,64 @@ module Exit_code = struct
   let internal_error = 125
 end
 
-module Appendable_list = struct
-  include Stdune.Appendable_list
+let sexp sexp = Pp.verbatim (Sexplib0.Sexp.to_string_hum sexp)
 
-  let append = ( @ )
-  let iter t ~f = List.iter f (to_list t)
+module Paragraph = struct
+  type t = Pp_tty.t
+
+  let recognize_sexp t =
+    match Pp.to_ast t with
+    | Verbatim str ->
+      (match Parsexp.Single.parse_string str with
+       | Ok sexp -> Some sexp
+       | Error _ -> None)
+    | _ -> None
+  ;;
+
+  let sexp_of_t t =
+    match recognize_sexp t with
+    | Some sexp -> sexp
+    | None ->
+      let str = Format.asprintf "%a" Pp.to_fmt (Pp.hbox t) in
+      Sexplib0.Sexp.Atom str
+  ;;
+
+  let rec simplify_sexp sexp =
+    match (sexp : Sexplib0.Sexp.t) with
+    | (Atom _ | List []) as sexp -> sexp
+    | List [ sexp ] -> simplify_sexp sexp
+    | List [ (Atom str as atom); List (List _ :: _ as sexps) ]
+      when not (String.contains str ' ') -> List (atom :: List.map simplify_sexp sexps)
+    | List sexps -> List (List.map simplify_sexp sexps)
+  ;;
+
+  let default_sexp_rendering = sexp
+
+  (* Future plans involve coloring the sexps when rendering to the console. *)
+  let pp_sexp sexp =
+    let sexp = simplify_sexp sexp in
+    let pp =
+      (* This is an heuristic to improve the rendering of errors built with the
+         [%sexp] extension, such as:
+
+         {[
+           [%sexp "Error message", { fields }]
+         }]
+      *)
+      match (sexp : Sexplib0.Sexp.t) with
+      | List (Atom atom :: (List _ :: _ as sexps)) when String.contains atom ' ' ->
+        Pp.O.(
+          Pp.verbatim atom ++ Pp.space ++ Pp.concat_map sexps ~f:default_sexp_rendering)
+      | sexp -> default_sexp_rendering sexp
+    in
+    Pp.box pp
+  ;;
+
+  let pp t =
+    match recognize_sexp t with
+    | Some sexp -> pp_sexp sexp
+    | None -> t
+  ;;
 end
 
 module Prefix = struct
@@ -41,32 +94,78 @@ let stdune_loc (loc : Loc.t) =
   Stdune.Loc.of_lexbuf_loc { start; stop }
 ;;
 
-let make_message ~prefix ?loc ?hints paragraphs =
+let make_message ~prefix ?loc ?(context = []) ?(hints = []) paragraphs =
   Stdune.User_message.make
     ?loc:(Option.map stdune_loc loc)
-    ?hints
+    ~hints
     ~prefix:
       (Pp.seq
          (Pp.tag (Prefix.style prefix) (Pp.verbatim (Prefix.to_string prefix)))
          (Pp.char ':'))
-    paragraphs
+    (List.map Paragraph.pp (List.concat [ context; paragraphs ]))
 ;;
 
-(* The messages are sorted and printed in the order they were raised. For
-   example, in [reraise], we insert the new message to the right most position
-   of [t.messages]. *)
 type t =
-  { messages : Stdune.User_message.t Appendable_list.t
+  { loc : Loc.t option
+  ; context : Paragraph.t list
+  ; paragraphs : Paragraph.t list
+  ; hints : Pp_tty.t list
   ; exit_code : Exit_code.t
   }
 
-let sexp_of_t { messages; exit_code } =
-  Sexplib0.Sexp.List
-    (List.map
-       (fun message -> Sexplib0.Sexp.Atom (Stdune.User_message.to_string message))
-       (Appendable_list.to_list messages)
-     @ [ List [ Atom "Exit"; Atom (Int.to_string exit_code) ] ])
+let to_sexps { loc; context; paragraphs; hints; exit_code = _ } =
+  List.concat
+    [ (match loc with
+       | None -> []
+       | Some loc ->
+         if Loc.include_sexp_of_locs.contents
+         then [ Sexplib0.Sexp.Atom (Loc.to_string loc) ]
+         else [])
+    ; (if List.is_empty context
+       then List.map Paragraph.sexp_of_t paragraphs
+       else
+         [ List (Atom "context" :: List.map Paragraph.sexp_of_t context)
+         ; List (Atom "error" :: List.map Paragraph.sexp_of_t paragraphs)
+         ])
+    ; (match hints with
+       | [] -> []
+       | _ :: _ -> [ List (Atom "hints" :: List.map Paragraph.sexp_of_t hints) ])
+    ]
 ;;
+
+let to_stdune_user_message ~prefix { loc; context; paragraphs; hints; exit_code = _ } =
+  if
+    List.is_empty paragraphs
+    && Option.is_none loc
+    && List.is_empty context
+    && List.is_empty hints
+  then None
+  else Some (make_message ~prefix ?loc ~context ~hints paragraphs)
+;;
+
+let sexp_of_t_internal ~include_exit_code t =
+  let sexps = to_sexps t in
+  let list =
+    List.concat
+      [ sexps
+      ; (if include_exit_code || List.is_empty sexps
+         then [ List [ Atom "exit_code"; Atom (Int.to_string t.exit_code) ] ]
+         else [])
+      ]
+  in
+  match list with
+  | [ sexp ] -> sexp
+  | [] | _ :: _ :: _ -> Sexplib0.Sexp.List list
+;;
+
+let sexp_of_t t = sexp_of_t_internal ~include_exit_code:false t
+let to_string_hum t = Sexplib0.Sexp.to_string_hum (sexp_of_t t)
+
+module With_exit_code = struct
+  type nonrec t = t
+
+  let sexp_of_t t = sexp_of_t_internal ~include_exit_code:true t
+end
 
 exception E of t
 
@@ -76,62 +175,37 @@ let () =
     | _ -> assert false)
 ;;
 
-let of_stdune_user_message ?(exit_code = Exit_code.some_error) t =
-  { messages = Appendable_list.singleton t; exit_code }
+let create
+      ?loc
+      ?(context = [])
+      ?(hints = [])
+      ?(exit_code = Exit_code.some_error)
+      paragraphs
+  =
+  { loc; context; paragraphs; hints; exit_code }
 ;;
 
-let create_error ?loc ?hints paragraphs =
-  Stdune.User_error.make ?loc:(Option.map stdune_loc loc) ?hints paragraphs
-;;
-
-let create ?loc ?hints ?exit_code paragraphs =
-  create_error ?loc ?hints paragraphs |> of_stdune_user_message ?exit_code
-;;
-
-let append ?exit_code t1 t2 =
-  let exit_code =
-    match exit_code with
-    | Some e -> e
-    | None -> t2.exit_code
-  in
-  { messages = Appendable_list.append t1.messages t2.messages; exit_code }
-;;
+let add_context t context = { t with context = context @ t.context }
 
 let raise ?loc ?hints ?exit_code paragraphs =
   Stdlib.raise (E (create ?loc ?hints ?exit_code paragraphs))
 ;;
 
-let reraise bt e ?loc ?hints ?(exit_code = Exit_code.some_error) paragraphs =
-  let message = create_error ?loc ?hints paragraphs in
-  Printexc.raise_with_backtrace
-    (E
-       { messages = Appendable_list.append e.messages (Appendable_list.singleton message)
-       ; exit_code
-       })
-    bt
+let reraise_with_context t bt context =
+  Printexc.raise_with_backtrace (E (add_context t context)) bt
 ;;
 
-let exit exit_code = Stdlib.raise (E { messages = Appendable_list.empty; exit_code })
+let exit exit_code =
+  Stdlib.raise (E { loc = None; context = []; paragraphs = []; hints = []; exit_code })
+;;
 
 let ok_exn = function
   | Ok x -> x
   | Error e -> Stdlib.raise (E e)
 ;;
 
+let of_exn exn = create [ sexp (Sexplib0.Sexp_conv.sexp_of_exn exn) ]
 let did_you_mean = Stdune.User_message.did_you_mean
-
-let sexp sexp =
-  let rec aux sexp =
-    match (sexp : Sexplib0.Sexp.t) with
-    | Atom s -> Pp.verbatim s
-    | List [ sexp ] -> aux sexp
-    | List _ -> Pp.verbatim (Sexplib0.Sexp.to_string_hum sexp)
-  in
-  match (sexp : Sexplib0.Sexp.t) with
-  | List (Atom atom :: sexps) ->
-    Pp.O.(Pp.verbatim atom ++ Pp.space ++ Pp.concat_map sexps ~f:aux)
-  | sexp -> aux sexp
-;;
 
 module Color_mode = struct
   type t =
@@ -221,7 +295,7 @@ let prerr_message (t : Stdune.User_message.t) =
 
 let prerr ?(reset_separator = false) (t : t) =
   if reset_separator then include_separator := false;
-  Appendable_list.iter t.messages ~f:prerr_message
+  Option.iter prerr_message (to_stdune_user_message ~prefix:Error t)
 ;;
 
 module Log_level = struct
@@ -304,8 +378,8 @@ let pp_backtrace backtrace =
     |> List.filter (fun s -> not (String.length s = 0))
 ;;
 
-let handle_messages_and_exit ~err:{ messages; exit_code } ~backtrace =
-  Appendable_list.iter messages ~f:prerr_message;
+let handle_messages_and_exit ~err:({ exit_code; _ } as t) ~backtrace =
+  Option.iter prerr_message (to_stdune_user_message ~prefix:Error t);
   if Int.equal exit_code Exit_code.internal_error
   then (
     let message =
@@ -407,8 +481,8 @@ let raise_s ?loc ?hints ?exit_code desc s =
   raise ?loc ?hints ?exit_code [ Pp.text desc; sexp s ] [@coverage off]
 ;;
 
-let reraise_s bt e ?loc ?hints ?exit_code desc s =
-  reraise bt e ?loc ?hints ?exit_code [ Pp.text desc; sexp s ] [@coverage off]
+let reraise_s bt e ?loc:_ ?hints:_ ?exit_code:_ desc s =
+  reraise_with_context e bt [ Pp.text desc; sexp s ] [@coverage off]
 ;;
 
 let pp_of_sexp = sexp

--- a/lib/err/src/err.ml
+++ b/lib/err/src/err.ml
@@ -155,7 +155,7 @@ let sexp_of_t_internal ~include_exit_code t =
   in
   match list with
   | [ sexp ] -> sexp
-  | [] | _ :: _ :: _ -> Sexplib0.Sexp.List list
+  | _ -> Sexplib0.Sexp.List list
 ;;
 
 let sexp_of_t t = sexp_of_t_internal ~include_exit_code:false t
@@ -204,7 +204,12 @@ let ok_exn = function
   | Error e -> Stdlib.raise (E e)
 ;;
 
-let of_exn exn = create [ sexp (Sexplib0.Sexp_conv.sexp_of_exn exn) ]
+let of_exn exn =
+  match (exn : exn) with
+  | E e -> e
+  | _ -> create [ sexp (Sexplib0.Sexp_conv.sexp_of_exn exn) ]
+;;
+
 let did_you_mean = Stdune.User_message.did_you_mean
 
 module Color_mode = struct

--- a/lib/err/src/err.ml
+++ b/lib/err/src/err.ml
@@ -36,6 +36,22 @@ module Prefix = struct
   ;;
 end
 
+let stdune_loc (loc : Loc.t) =
+  let { Loc.Lexbuf_loc.start; stop } = Loc.to_lexbuf_loc loc in
+  Stdune.Loc.of_lexbuf_loc { start; stop }
+;;
+
+let make_message ~prefix ?loc ?hints paragraphs =
+  Stdune.User_message.make
+    ?loc:(Option.map stdune_loc loc)
+    ?hints
+    ~prefix:
+      (Pp.seq
+         (Pp.tag (Prefix.style prefix) (Pp.verbatim (Prefix.to_string prefix)))
+         (Pp.char ':'))
+    paragraphs
+;;
+
 (* The messages are sorted and printed in the order they were raised. For
    example, in [reraise], we insert the new message to the right most position
    of [t.messages]. *)
@@ -62,11 +78,6 @@ let () =
 
 let of_stdune_user_message ?(exit_code = Exit_code.some_error) t =
   { messages = Appendable_list.singleton t; exit_code }
-;;
-
-let stdune_loc (loc : Loc.t) =
-  let { Loc.Lexbuf_loc.start; stop } = Loc.to_lexbuf_loc loc in
-  Stdune.Loc.of_lexbuf_loc { start; stop }
 ;;
 
 let create_error ?loc ?hints paragraphs =
@@ -211,17 +222,6 @@ let prerr_message (t : Stdune.User_message.t) =
 let prerr ?(reset_separator = false) (t : t) =
   if reset_separator then include_separator := false;
   Appendable_list.iter t.messages ~f:prerr_message
-;;
-
-let make_message ~prefix ?loc ?hints paragraphs =
-  Stdune.User_message.make
-    ?loc:(Option.map stdune_loc loc)
-    ?hints
-    ~prefix:
-      (Pp.seq
-         (Pp.tag (Prefix.style prefix) (Pp.verbatim (Prefix.to_string prefix)))
-         (Pp.char ':'))
-    paragraphs
 ;;
 
 module Log_level = struct

--- a/lib/err/src/err.mli
+++ b/lib/err/src/err.mli
@@ -157,8 +157,9 @@ val reraise_with_context : t -> Printexc.raw_backtrace -> Pp_tty.t list -> _
     - [ok_exn (Error msg)] is [Stdlib.raise (E msg)] *)
 val ok_exn : ('a, t) result -> 'a
 
-(** Build an error from an exception. This uses the sexp of the exception under
-    the hood. *)
+(** Build an error from an exception. This retrieves [e] if the exception is
+    [Err.E e], otherwise this creates a new error using the sexp of the
+    supplied exception. *)
 val of_exn : exn -> t
 
 (** {1 Hints} *)

--- a/lib/err/test/test__catching_err.ml
+++ b/lib/err/test/test__catching_err.ml
@@ -27,7 +27,7 @@ let had_errors () =
 let%expect_test "catch" =
   Err.Private.reset_counts ();
   require_does_raise [%here] (fun () -> Lib.raise ());
-  [%expect {| ("Hello from raising library" (Exit 123)) |}];
+  [%expect {| "Hello from raising library" |}];
   had_errors ();
   [%expect {| ((had_errors false)) |}];
   Err.For_test.protect (fun () ->

--- a/lib/err/test/test__err.ml
+++ b/lib/err/test/test__err.ml
@@ -52,24 +52,15 @@ let%expect_test "reraise" =
     | _ -> assert false
     | exception Err.E e ->
       let bt = Stdlib.Printexc.get_raw_backtrace () in
-      Err.reraise
-        bt
-        e
-        ~loc:(Loc.of_file ~path:(Fpath.v "path/to/other-file.txt"))
-        ~exit_code:Err.Exit_code.internal_error
-        [ Pp.text "Re raised with context"; Pp.verbatim "x" ]);
+      Err.reraise_with_context e bt [ Pp.text "Re raised with context"; Pp.verbatim "x" ]);
   [%expect
     {|
     File "path/to/my-file.txt", line 1, characters 0-0:
-    Error: Hello Raise
-    Hint: did you mean bar?
-
-    File "path/to/other-file.txt", line 1, characters 0-0:
     Error: Re raised with context
     x
-
-    Backtrace: <backtrace disabled in tests>
-    [125]
+    Hello Raise
+    Hint: did you mean bar?
+    [123]
     |}];
   ()
 ;;
@@ -92,38 +83,54 @@ let%expect_test "create" =
   ()
 ;;
 
-let%expect_test "append" =
+let%expect_test "sexp_of_t" =
+  let err =
+    Err.create
+      ~loc:(Loc.of_file ~path:(Fpath.v "path/to/my-file.txt"))
+      ~hints:(Err.did_you_mean "bah" ~candidates:[ "bar"; "foo" ])
+      [ Pp.text "Hello Sexp"; Err.sexp [%sexp { a = Hello; b = 42 }] ]
+  in
+  print_s [%sexp (err : Err.t)];
+  [%expect
+    {|
+    ("Hello Sexp"
+      ((a Hello)
+       (b 42))
+      (hints "did you mean bar?"))
+    |}];
+  print_endline (Err.to_string_hum err);
+  [%expect {| ("Hello Sexp" ((a Hello) (b 42)) (hints "did you mean bar?")) |}];
+  ()
+;;
+
+let%expect_test "add_context" =
   let err1 =
     Err.create
       ~loc:(Loc.of_file ~path:(Fpath.v "path/to/my-file-1.txt"))
       ~exit_code:41
       [ Pp.text "Hello Error 1" ]
   in
-  let err2 =
-    Err.create
-      ~loc:(Loc.of_file ~path:(Fpath.v "path/to/my-file-2.txt"))
-      ~exit_code:42
-      [ Pp.text "Hello Error 2" ]
-  in
-  Err.For_test.protect (fun () -> raise (Err.E (Err.append err1 err2)));
+  let err2 = Err.add_context err1 [ Pp.text "Hello Context 1" ] in
+  Err.For_test.protect (fun () -> raise (Err.E err2));
   [%expect
     {|
     File "path/to/my-file-1.txt", line 1, characters 0-0:
-    Error: Hello Error 1
-
-    File "path/to/my-file-2.txt", line 1, characters 0-0:
-    Error: Hello Error 2
-    [42]
+    Error: Hello Context 1
+    Hello Error 1
+    [41]
     |}];
-  Err.For_test.protect (fun () -> raise (Err.E (Err.append err1 err2 ~exit_code:2)));
+  let err3 =
+    Err.add_context err2 [ Pp.text "Hello Context 2"; Err.sexp [%sexp Hello Sexp] ]
+  in
+  Err.For_test.protect (fun () -> raise (Err.E err3));
   [%expect
     {|
     File "path/to/my-file-1.txt", line 1, characters 0-0:
-    Error: Hello Error 1
-
-    File "path/to/my-file-2.txt", line 1, characters 0-0:
-    Error: Hello Error 2
-    [2]
+    Error: Hello Context 2
+    (Hello Sexp)
+    Hello Context 1
+    Hello Error 1
+    [41]
     |}];
   ()
 ;;
@@ -153,7 +160,7 @@ let%expect_test "create_s" =
     Err.create
       ~loc:(Loc.of_file ~path:(Fpath.v "path/to/my-file.txt"))
       ~hints:(Err.did_you_mean "bah" ~candidates:[ "bar"; "foo" ])
-      [ Pp.text "The summary of the error"
+      [ Pp.text "The summary of the error."
       ; Err.sexp [%sexp { x = 42; y = Some "msg"; var = "bah" }]
       ]
   in
@@ -161,7 +168,7 @@ let%expect_test "create_s" =
   [%expect
     {|
     File "path/to/my-file.txt", line 1, characters 0-0:
-    Error: The summary of the error
+    Error: The summary of the error.
     ((x 42) (y (Some msg)) (var bah))
     Hint: did you mean bar?
     [123]
@@ -169,7 +176,7 @@ let%expect_test "create_s" =
   ()
 ;;
 
-let%expect_test "raise_s" =
+let%expect_test "raise with sexp" =
   Err.For_test.protect (fun () ->
     Err.raise
       ~loc:(Loc.of_file ~path:(Fpath.v "path/to/my-file.txt"))
@@ -183,10 +190,22 @@ let%expect_test "raise_s" =
     Hint: did you mean bar?
     [123]
     |}];
+  Err.For_test.protect (fun () ->
+    Err.raise
+      ~loc:(Loc.of_file ~path:(Fpath.v "path/to/my-file.txt"))
+      ~hints:(Err.did_you_mean "bah" ~candidates:[ "bar"; "foo" ])
+      Pp.O.[ Pp.text "Hello Raise " ++ Err.sexp [%sexp { hello = 42 }] ]);
+  [%expect
+    {|
+    File "path/to/my-file.txt", line 1, characters 0-0:
+    Error: Hello Raise ((hello 42))
+    Hint: did you mean bar?
+    [123]
+    |}];
   ()
 ;;
 
-let%expect_test "reraise_s" =
+let%expect_test "reraise_with_context" =
   Err.For_test.protect (fun () ->
     match
       Err.raise
@@ -197,21 +216,18 @@ let%expect_test "reraise_s" =
     | _ -> assert false
     | exception Err.E e ->
       let bt = Stdlib.Printexc.get_raw_backtrace () in
-      Err.reraise
-        bt
+      Err.reraise_with_context
         e
-        ~loc:(Loc.of_file ~path:(Fpath.v "path/to/other-file.txt"))
+        bt
         [ Pp.text "Re raised with context"; Err.sexp [%sexp { x = 42 }] ]);
   [%expect
     {|
     File "path/to/my-file.txt", line 1, characters 0-0:
-    Error: Hello Raise
-    (hello 42)
-    Hint: did you mean bar?
-
-    File "path/to/other-file.txt", line 1, characters 0-0:
     Error: Re raised with context
     (x 42)
+    Hello Raise
+    (hello 42)
+    Hint: did you mean bar?
     [123]
     |}];
   ()
@@ -230,7 +246,9 @@ let%expect_test "prerr" =
       ~exit_code:42
       [ Pp.text "Hello Error 2" ]
   in
-  Err.For_test.protect (fun () -> Err.prerr (Err.append err1 err2));
+  Err.For_test.protect (fun () ->
+    Err.prerr err1;
+    Err.prerr err2);
   [%expect
     {|
     File "path/to/my-file-1.txt", line 1, characters 0-0:
@@ -241,21 +259,13 @@ let%expect_test "prerr" =
     |}];
   (* The fact is that [%expect _] strips the output to compare, so the leading
      blank line is not visible here. *)
-  Err.For_test.protect (fun () -> Err.prerr (Err.append err1 err2));
+  Err.For_test.protect (fun () ->
+    Err.prerr err1;
+    Err.prerr err2 ~reset_separator:true);
   [%expect
     {|
     File "path/to/my-file-1.txt", line 1, characters 0-0:
     Error: Hello Error 1
-
-    File "path/to/my-file-2.txt", line 1, characters 0-0:
-    Error: Hello Error 2
-    |}];
-  Err.For_test.protect (fun () -> Err.prerr (Err.append err1 err2) ~reset_separator:true);
-  [%expect
-    {|
-    File "path/to/my-file-1.txt", line 1, characters 0-0:
-    Error: Hello Error 1
-
     File "path/to/my-file-2.txt", line 1, characters 0-0:
     Error: Hello Error 2
     |}];
@@ -463,7 +473,7 @@ let%expect_test "non-test handler" =
 
 let%expect_test "raise without handler" =
   require_does_raise [%here] (fun () -> Err.raise [ Pp.text "Hello" ]);
-  [%expect {| (Hello (Exit 123)) |}];
+  [%expect {| Hello |}];
   ()
 ;;
 

--- a/lib/err/test/test__err.ml
+++ b/lib/err/test/test__err.ml
@@ -33,6 +33,20 @@ let%expect_test "raise" =
   ()
 ;;
 
+let%expect_test "of_exn" =
+  let e = Err.create [ Pp.text "Hello of_exn" ] in
+  let e' = Err.of_exn (Err.E e) in
+  require [%here] (phys_equal e e');
+  [%expect {||}];
+  let e =
+    try failwith "Hello Exn!" with
+    | e -> Err.of_exn e
+  in
+  print_s [%sexp (e : Err.t)];
+  [%expect {| (Failure "Hello Exn!") |}];
+  ()
+;;
+
 let%expect_test "exit" =
   Err.For_test.protect (fun () -> Err.exit 0);
   [%expect {||}];

--- a/lib/err/test/test__exit_codes.ml
+++ b/lib/err/test/test__exit_codes.ml
@@ -57,3 +57,14 @@ let%expect_test "exit without handler" =
   [%expect {| (exit_code 123) |}];
   ()
 ;;
+
+let%expect_test "exit_code in sexp" =
+  let e = Err.create [ Pp.text "Hello Exit Code" ] in
+  print_s [%sexp (e : Err.t)];
+  [%expect {| "Hello Exit Code" |}];
+  require_does_raise [%here] (fun () -> raise (Err.E e));
+  [%expect {| "Hello Exit Code" |}];
+  print_s [%sexp (e : Err.With_exit_code.t)];
+  [%expect {| ("Hello Exit Code" (exit_code 123)) |}];
+  ()
+;;

--- a/lib/err/test/test__exit_codes.ml
+++ b/lib/err/test/test__exit_codes.ml
@@ -52,8 +52,8 @@ let%expect_test "exit" =
 
 let%expect_test "exit without handler" =
   require_does_raise [%here] (fun () -> Err.exit Err.Exit_code.ok);
-  [%expect {| ((Exit 0)) |}];
+  [%expect {| (exit_code 0) |}];
   require_does_raise [%here] (fun () -> Err.exit Err.Exit_code.some_error);
-  [%expect {| ((Exit 123)) |}];
+  [%expect {| (exit_code 123) |}];
   ()
 ;;

--- a/lib/err/test/test__pp_of_sexp.ml
+++ b/lib/err/test/test__pp_of_sexp.ml
@@ -1,46 +1,166 @@
 let%expect_test "pp_of_sexp" =
-  let test sexp = Err.For_test.protect (fun () -> Err.raise [ Err.sexp sexp ]) in
+  let test sexp =
+    let err = Err.create [ Err.sexp sexp ] in
+    print_endline "========= sexp ==========";
+    print_endline (Sexp.to_string_hum (Err.sexp_of_t err));
+    print_endline "======== console ========";
+    Err.prerr err ~reset_separator:true
+  in
   test [%sexp ()];
   [%expect
     {|
+    ========= sexp ==========
+    ()
+    ======== console ========
     Error: ()
-    [123]
     |}];
   test [%sexp "Hello"];
   [%expect
     {|
+    ========= sexp ==========
+    Hello
+    ======== console ========
     Error: Hello
-    [123]
     |}];
   test [%sexp "Hello error", { x = 42 }];
   [%expect
     {|
+    ========= sexp ==========
+    ("Hello error" ((x 42)))
+    ======== console ========
     Error: Hello error (x 42)
-    [123]
     |}];
   test [%sexp { x = 42 }];
   [%expect
     {|
+    ========= sexp ==========
+    ((x 42))
+    ======== console ========
     Error: (x 42)
-    [123]
     |}];
   test [%sexp { x = 42; y = "why" }];
   [%expect
     {|
+    ========= sexp ==========
+    ((x 42) (y why))
+    ======== console ========
     Error: ((x 42) (y why))
-    [123]
     |}];
   test [%sexp "Hello error", { x = 42 }];
   [%expect
     {|
+    ========= sexp ==========
+    ("Hello error" ((x 42)))
+    ======== console ========
     Error: Hello error (x 42)
-    [123]
     |}];
   test [%sexp "Hello error", { x = 42; y = "why" }];
   [%expect
     {|
+    ========= sexp ==========
+    ("Hello error" ((x 42) (y why)))
+    ======== console ========
     Error: Hello error ((x 42) (y why))
-    [123]
+    |}];
+  test [%sexp Var { x = 42; y = "why" }];
+  [%expect
+    {|
+    ========= sexp ==========
+    (Var ((x 42) (y why)))
+    ======== console ========
+    Error: (Var (x 42) (y why))
+    |}];
+  ()
+;;
+
+let sexp_vs_prerr err =
+  print_endline "========= sexp ==========";
+  print_s (Err.sexp_of_t err);
+  print_endline "======== console ========";
+  Err.prerr err ~reset_separator:true
+;;
+
+let%expect_test "sexp vs prerr" =
+  let test = sexp_vs_prerr in
+  let err = Err.create [ Pp.verbatim "Hello World" ] in
+  test err;
+  [%expect
+    {|
+    ========= sexp ==========
+    "Hello World"
+    ======== console ========
+    Error: Hello World
+    |}];
+  let err = Err.add_context err [ Pp.text "Hello Context!" ] in
+  test err;
+  [%expect
+    {|
+    ========= sexp ==========
+    ((context "Hello Context!")
+     (error   "Hello World"))
+    ======== console ========
+    Error: Hello Context!
+    Hello World
+    |}];
+  let err =
+    Err.add_context
+      err
+      [ Err.sexp [%sexp "And even more context", { x = 42; y = "Foo" }] ]
+  in
+  test err;
+  [%expect
+    {|
+    ========= sexp ==========
+    ((context
+       ("And even more context" (
+         (x 42)
+         (y Foo)))
+       "Hello Context!")
+     (error "Hello World"))
+    ======== console ========
+    Error: And even more context ((x 42) (y Foo))
+    Hello Context!
+    Hello World
+    |}];
+  ()
+;;
+
+let%expect_test "with positions" =
+  let file_cache =
+    Loc.File_cache.create
+      ~path:(Fpath.v "foo.txt")
+      ~file_contents:
+        {|
+Hello File
+With Multiple lines
+|}
+  in
+  let loc = Loc.of_file_line ~file_cache ~line:1 in
+  let err =
+    Err.create ~loc [ Pp.text "Hello Located Error" ] ~hints:[ Pp.text "With hints too!" ]
+  in
+  let test = sexp_vs_prerr in
+  test err;
+  [%expect
+    {|
+    ========= sexp ==========
+    ("Hello Located Error" (hints "With hints too!"))
+    ======== console ========
+    File "foo.txt", line 1, characters 0-0:
+    Error: Hello Located Error
+    Hint: With hints too!
+    |}];
+  Ref.set_temporarily Loc.include_sexp_of_locs true ~f:(fun () -> test err);
+  [%expect
+    {|
+    ========= sexp ==========
+    ("File \"foo.txt\", line 1, characters 0-0:"
+     "Hello Located Error"
+     (hints "With hints too!"))
+    ======== console ========
+    File "foo.txt", line 1, characters 0-0:
+    Error: Hello Located Error
+    Hint: With hints too!
     |}];
   ()
 ;;


### PR DESCRIPTION
### Added

- Add concept of error "context" that can be augmented.
- Better support and rendering of errors built with `Err.sexp`.

### Changed

- Tweak some details in format of `Err.sexp_of_t`.
- Do not include exit code in `Err.sexp_of_t` by default.

### Removed

- Replaced `Err.append` by `Err.add_context`.
