### PR TITLE
Err level

### DIFF
--- a/lib/err/src/err.ml
+++ b/lib/err/src/err.ml
@@ -436,6 +436,18 @@ let debug ?loc ?hints paragraphs =
     prerr_message message)
 ;;
 
+let emit t ~level =
+  if log_enables ~level
+  then
+    to_stdune_user_message t ~level
+    |> Option.iter (fun message ->
+      (match level with
+       | Error -> incr error_count_value
+       | Warning -> incr warning_count_value
+       | Info | Debug -> ());
+      prerr_message message)
+;;
+
 let pp_backtrace backtrace =
   if am_running_test ()
   then [ "<backtrace disabled in tests>" ]

--- a/lib/err/src/err.ml
+++ b/lib/err/src/err.ml
@@ -226,7 +226,22 @@ module Color_mode = struct
     | `Never
     ]
 
+  let sexp_of_t : t -> Sexplib0.Sexp.t = function
+    | `Auto -> Atom "Auto"
+    | `Always -> Atom "Always"
+    | `Never -> Atom "Never"
+  ;;
+
   let all : t list = [ `Auto; `Always; `Never ]
+
+  let to_index = function
+    | `Auto -> 0
+    | `Always -> 1
+    | `Never -> 2
+  ;;
+
+  let compare l1 l2 = Int.compare (to_index l1) (to_index l2)
+  let equal l1 l2 = Int.equal (to_index l1) (to_index l2)
 
   let to_string : t -> string = function
     | `Auto -> "auto"
@@ -319,6 +334,15 @@ module Log_level = struct
     | Info
     | Debug
 
+  let sexp_of_t : t -> Sexplib0.Sexp.t = function
+    | Quiet -> Atom "Quiet"
+    | App -> Atom "App"
+    | Error -> Atom "Error"
+    | Warning -> Atom "Warning"
+    | Info -> Atom "Info"
+    | Debug -> Atom "Debug"
+  ;;
+
   let all = [ Quiet; App; Error; Warning; Info; Debug ]
 
   let to_index = function
@@ -331,6 +355,7 @@ module Log_level = struct
   ;;
 
   let compare l1 l2 = Int.compare (to_index l1) (to_index l2)
+  let equal l1 l2 = Int.equal (to_index l1) (to_index l2)
 
   let to_string = function
     | Quiet -> "quiet"

--- a/lib/err/src/err.mli
+++ b/lib/err/src/err.mli
@@ -234,7 +234,7 @@ end
 
 val color_mode : unit -> Color_mode.t
 
-(** {2 Log Level}
+(** {2 Messages and Log Levels}
 
     Inspired by logging conventions in many CLI tools, this library provides a
     mechanism to control the verbosity of log messages based on their severity
@@ -261,7 +261,7 @@ val color_mode : unit -> Color_mode.t
     Example usage:
 
     {[
-      if Err.log_enables Debug
+      if Err.log_enables ~level:Debug
       then (
         (* Perform expensive debugging operations *)
         let debug_data = compute_debug_data () in
@@ -300,12 +300,37 @@ module Log_level : sig
   val to_string : t -> string
 end
 
+module Level : sig
+  (** A level for individual messages (by contrast to the current level of the
+      log).
+
+      Seeing how a message of level [Quiet] would not make sense, this module
+      distinguishes the two types.
+
+      Message of levels [App] are not supported by this library. Consider using
+      [Log] if interested. *)
+
+  type t =
+    | Error
+    | Warning
+    | Info
+    | Debug
+
+  val sexp_of_t : t -> Sexplib0.Sexp.t
+  val all : t list
+  val compare : t -> t -> int
+  val equal : t -> t -> bool
+
+  (** Return an uncapitalized string representing the variant constructor. *)
+  val to_string : t -> string
+end
+
 (** Access the current log level. *)
 val log_level : unit -> Log_level.t
 
 (** Tell whether the current log level enables the output of messages of the
     supplied level. *)
-val log_enables : Log_level.t -> bool
+val log_enables : level:Level.t -> bool
 
 (** {1 Printing messages} *)
 

--- a/lib/err/src/err.mli
+++ b/lib/err/src/err.mli
@@ -362,10 +362,12 @@ val to_string_hum : t -> string
     [warning_count]), which is going to be used by {!val:protect} to impact the
     exit code of the application. Use with care. *)
 
-(** Emit an error on stderr and increase the global error count. *)
+(** Emit an error on stderr and increase the global error count. Requires a log
+    level of [Error] or more, enabled by default. *)
 val error : ?loc:Loc.t -> ?hints:Pp_tty.t list -> Pp_tty.t list -> unit
 
-(** Emit a warning on stderr and increase the global warning count. *)
+(** Emit a warning on stderr and increase the global warning count. Requires a
+    log level of [Warning] or more, enabled by default. *)
 val warning : ?loc:Loc.t -> ?hints:Pp_tty.t list -> Pp_tty.t list -> unit
 
 (** Emit a information message on stderr. Required verbosity level of [Info] or
@@ -378,6 +380,24 @@ val info : ?loc:Loc.t -> ?hints:Pp_tty.t list -> Pp_tty.t list -> unit
     impacts the program's performance, and using lazy causes added programming
     friction. *)
 val debug : ?loc:Loc.t -> ?hints:Pp_tty.t list -> Pp_tty.t list Lazy.t -> unit
+
+(** Emit a message from an existing error.
+
+    Rather than building a new [Err.t], this part of the API allows you to emit
+    a message from a previously created err value. For example, you may catch an
+    error raised by some code, and make that a warning instead.
+
+    {[
+      let warn_on_error ~f =
+        try f () with
+        | Err e -> Err.emit t ~level:Warning
+      ;;
+    ]}
+
+    The emit functions does check the current log level, and only emit the message
+    if permitted it - for example, [emit t ~level:Warning] actually emits a warning
+    only when [log_enables ~level:Warning = true]. *)
+val emit : t -> level:Level.t -> unit
 
 (** {1 Handler}
 

--- a/lib/err/src/err.mli
+++ b/lib/err/src/err.mli
@@ -223,7 +223,12 @@ module Color_mode : sig
     | `Never
     ]
 
+  val sexp_of_t : t -> Sexplib0.Sexp.t
   val all : t list
+  val compare : t -> t -> int
+  val equal : t -> t -> bool
+
+  (** Return an uncapitalized string representing the variant constructor. *)
   val to_string : t -> string
 end
 
@@ -271,9 +276,9 @@ val color_mode : unit -> Color_mode.t
     (e.g., [--verbosity=debug]). This ensures consistent behavior across
     applications using this library.
 
-    Note: A level named [App] has been added to ensure compatibility with the
-    [Logs] library, as this constructor is part of [Logs.level]. However, this
-    module does not differentiate between the [Quiet] and [App] levels. The
+    Note: A log level named [App] has been added to ensure compatibility with
+    the [Logs] library, as this constructor is part of [Logs.level]. However,
+    this module does not differentiate between the [Quiet] and [App] levels. The
     [App] level is primarily included to facilitate interoperability with
     third-party libraries that rely on [Logs]. *)
 
@@ -286,8 +291,12 @@ module Log_level : sig
     | Info
     | Debug
 
+  val sexp_of_t : t -> Sexplib0.Sexp.t
   val all : t list
   val compare : t -> t -> int
+  val equal : t -> t -> bool
+
+  (** Return an uncapitalized string representing the variant constructor. *)
   val to_string : t -> string
 end
 

--- a/lib/err/test/cram/logs.t
+++ b/lib/err/test/cram/logs.t
@@ -1,0 +1,31 @@
+Exercising some behavior of the Logs library for reference.
+
+By default app, err, and warn messages are enabled.
+
+  $ ./main.exe logs
+  Hello app
+  main.exe: [ERROR] Hello err
+  main.exe: [WARNING] Hello warn
+  [1]
+
+All messages are enabled in debug mode.
+
+  $ ./main.exe logs --verbosity=debug
+  Hello app
+  main.exe: [ERROR] Hello err
+  main.exe: [WARNING] Hello warn
+  main.exe: [INFO] Hello info
+  main.exe: [DEBUG] Hello debug
+  [1]
+
+In app mode, the errors are silenced.
+
+  $ ./main.exe logs --verbosity=app
+  Hello app
+  [1]
+
+When in quiet mode, all outputs are silenced.
+
+  $ ./main.exe logs --verbosity=quiet
+
+And we note that the exit code is [0].

--- a/lib/err/test/cram/run.t
+++ b/lib/err/test/cram/run.t
@@ -6,7 +6,7 @@ Exercising the error handling from the command line.
 
   $ ./main.exe write --file file --line 1 --pos-bol 0 \
   > --pos-cnum 0 --length 5 \
-  > --message-kind=error
+  > --level=error
   File "file", line 1, characters 0-5:
   1 | Hello World
       ^^^^^
@@ -15,7 +15,7 @@ Exercising the error handling from the command line.
 
   $ ./main.exe write --file file --line 1 --pos-bol 0 \
   > --pos-cnum 6 --length 5 \
-  > --message-kind=warning
+  > --level=warning
   File "file", line 1, characters 6-11:
   1 | Hello World
             ^^^^^
@@ -23,7 +23,7 @@ Exercising the error handling from the command line.
 
   $ ./main.exe write --file file --line 1 --pos-bol 0 \
   > --pos-cnum 6 --length 5 \
-  > --message-kind=warning \
+  > --level=warning \
   > --warn-error
   File "file", line 1, characters 6-11:
   1 | Hello World
@@ -33,11 +33,11 @@ Exercising the error handling from the command line.
 
   $ ./main.exe write --file file --line 1 --pos-bol 0 \
   > --pos-cnum 6 --length 5 \
-  > --message-kind=info
+  > --level=info
 
   $ ./main.exe write --file file --line 1 --pos-bol 0 \
   > --pos-cnum 6 --length 5 \
-  > --message-kind=info \
+  > --level=info \
   > --verbose
   File "file", line 1, characters 6-11:
   1 | Hello World
@@ -46,12 +46,12 @@ Exercising the error handling from the command line.
 
   $ ./main.exe write --file file --line 1 --pos-bol 0 \
   > --pos-cnum 6 --length 5 \
-  > --message-kind=debug \
+  > --level=debug \
   > --verbose
 
   $ ./main.exe write --file file --line 1 --pos-bol 0 \
   > --pos-cnum 6 --length 5 \
-  > --message-kind=debug \
+  > --level=debug \
   > --verbosity=debug
   File "file", line 1, characters 6-11:
   1 | Hello World
@@ -63,11 +63,11 @@ Exercising the error handling from the command line.
   > --raise 2>&1 | head -n 1
   Internal Error: Failure("Raising an exception!")
 
-Logs and Fmt options
+Logs and Fmt options.
 
   $ ./main.exe write --file file --line 1 --pos-bol 0 \
   > --pos-cnum 0 --length 5 \
-  > --message-kind=error \
+  > --level=error \
   > --color=always
   File "file", line 1, characters 0-5:
   1 | Hello World
@@ -77,10 +77,24 @@ Logs and Fmt options
 
   $ ./main.exe write --file file --line 1 --pos-bol 0 \
   > --pos-cnum 0 --length 5 \
-  > --message-kind=error \
+  > --level=error \
   > --color=never
   File "file", line 1, characters 0-5:
   1 | Hello World
       ^^^^^
   Error: error message
   [123]
+
+When the log level is 'quiet', even errors should not be shown.
+
+  $ ./main.exe write --file file --line 1 --pos-bol 0 \
+  > --pos-cnum 0 --length 5 \
+  > --level=error \
+  > --verbosity=quiet
+
+The rendering part works as expected for emitted errors, however currently we
+note a potential source of confusion: since errors are disabled due to the quiet
+log level, they are not accounted for at all in the exit code.
+
+We are keeping this as characterization here, however this may be subject to
+change in future versions.

--- a/lib/err/test/test__color_mode.ml
+++ b/lib/err/test/test__color_mode.ml
@@ -4,27 +4,41 @@
 (*  SPDX-License-Identifier: MIT                                                 *)
 (*********************************************************************************)
 
-module Color_mode = struct
-  type t =
-    [ `Always
-    | `Auto
-    | `Never
-    ]
-  [@@deriving equal, enumerate, sexp_of]
-end
-
 let%expect_test "color_mode" =
-  List.iter Color_mode.all ~f:(fun color_mode ->
+  List.iter Err.Color_mode.all ~f:(fun color_mode ->
     Err.Private.color_mode := color_mode;
     let color_mode' = Err.color_mode () in
-    require_equal [%here] (module Color_mode) color_mode color_mode';
-    print_s [%sexp (color_mode' : Color_mode.t)]);
+    require_equal [%here] (module Err.Color_mode) color_mode color_mode';
+    print_s [%sexp (color_mode' : Err.Color_mode.t)]);
   [%expect
     {|
-    Always
     Auto
+    Always
     Never
     |}];
   Err.Private.color_mode := `Auto;
+  ()
+;;
+
+let%expect_test "to_string" =
+  List.iter Err.Color_mode.all ~f:(fun log_level ->
+    print_endline (Err.Color_mode.to_string log_level));
+  [%expect
+    {|
+    auto
+    always
+    never
+    |}];
+  ()
+;;
+
+let%expect_test "compare" =
+  List.iter Err.Color_mode.all ~f:(fun log_level ->
+    require [%here] (Err.Color_mode.equal log_level log_level);
+    require [%here] (0 = Err.Color_mode.compare log_level log_level));
+  require [%here] (not (Err.Color_mode.equal `Never `Always));
+  require [%here] (Err.Color_mode.compare `Never `Auto > 0);
+  require [%here] (Err.Color_mode.compare `Auto `Always < 0);
+  [%expect {||}];
   ()
 ;;

--- a/lib/err/test/test__level.ml
+++ b/lib/err/test/test__level.ml
@@ -1,0 +1,41 @@
+(*********************************************************************************)
+(*  pplumbing - Utility libraries to use with [pp]                               *)
+(*  SPDX-FileCopyrightText: 2024-2025 Mathieu Barbin <mathieu.barbin@gmail.com>  *)
+(*  SPDX-License-Identifier: MIT                                                 *)
+(*********************************************************************************)
+
+let%expect_test "sexp_of_t" =
+  List.iter Err.Level.all ~f:(fun log_level -> print_s [%sexp (log_level : Err.Level.t)]);
+  [%expect
+    {|
+    Error
+    Warning
+    Info
+    Debug
+    |}];
+  ()
+;;
+
+let%expect_test "to_string" =
+  List.iter Err.Level.all ~f:(fun log_level ->
+    print_endline (Err.Level.to_string log_level));
+  [%expect
+    {|
+    error
+    warning
+    info
+    debug
+    |}];
+  ()
+;;
+
+let%expect_test "compare" =
+  List.iter Err.Level.all ~f:(fun log_level ->
+    require [%here] (Err.Level.equal log_level log_level);
+    require [%here] (0 = Err.Level.compare log_level log_level));
+  require [%here] (not (Err.Level.equal Error Warning));
+  require [%here] (Err.Level.compare Error Warning < 0);
+  require [%here] (Err.Level.compare Debug Error > 0);
+  [%expect {||}];
+  ()
+;;

--- a/lib/err/test/test__level.mli
+++ b/lib/err/test/test__level.mli
@@ -1,0 +1,5 @@
+(*_********************************************************************************)
+(*_  pplumbing - Utility libraries to use with [pp]                               *)
+(*_  SPDX-FileCopyrightText: 2024-2025 Mathieu Barbin <mathieu.barbin@gmail.com>  *)
+(*_  SPDX-License-Identifier: MIT                                                 *)
+(*_********************************************************************************)

--- a/lib/err/test/test__log_level.ml
+++ b/lib/err/test/test__log_level.ml
@@ -4,6 +4,47 @@
 (*  SPDX-License-Identifier: MIT                                                 *)
 (*********************************************************************************)
 
+let%expect_test "sexp_of_t" =
+  List.iter Err.Log_level.all ~f:(fun log_level ->
+    print_s [%sexp (log_level : Err.Log_level.t)]);
+  [%expect
+    {|
+    Quiet
+    App
+    Error
+    Warning
+    Info
+    Debug
+    |}];
+  ()
+;;
+
+let%expect_test "to_string" =
+  List.iter Err.Log_level.all ~f:(fun log_level ->
+    print_endline (Err.Log_level.to_string log_level));
+  [%expect
+    {|
+    quiet
+    app
+    error
+    warning
+    info
+    debug
+    |}];
+  ()
+;;
+
+let%expect_test "compare" =
+  List.iter Err.Log_level.all ~f:(fun log_level ->
+    require [%here] (Err.Log_level.equal log_level log_level);
+    require [%here] (0 = Err.Log_level.compare log_level log_level));
+  require [%here] (not (Err.Log_level.equal Error Warning));
+  require [%here] (Err.Log_level.compare Error Warning < 0);
+  require [%here] (Err.Log_level.compare Debug Error > 0);
+  [%expect {||}];
+  ()
+;;
+
 let%expect_test "log levels" =
   Err.Private.reset_counts ();
   Err.For_test.wrap


### PR DESCRIPTION
- Mint a sub-type of log levels dedicated to emit messages.
- Document current behavior of interaction between `quiet` mode and `error-count` (with work in progress to follow up and change this).