### PR TITLE
Quiet raise

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Do not print raised errors and exceptions when in quiet mode (#9, @mbarbin).
+
 ### Removed
 
 ## 0.0.12 (2025-05-06)

--- a/lib/err/test/cram/main.ml
+++ b/lib/err/test/cram/main.ml
@@ -35,12 +35,15 @@ let write_cmd =
          ~default:Error
          ~docv:"LEVEL"
          ~doc:"The level of the message to emit."
-     and+ raise = Arg.flag [ "raise" ] ~doc:"raise an exception" in
+     and+ uncaught_exception =
+       Arg.flag [ "uncaught-exception" ] ~doc:"Raise an uncaught exception."
+     and+ err_raise = Arg.flag [ "err-raise" ] ~doc:"Raise an error with [Err.raise]." in
      let loc =
        let p = { Lexing.pos_fname = file; pos_lnum = line; pos_cnum; pos_bol } in
        Loc.create (p, { p with pos_cnum = pos_cnum + length })
      in
-     if raise then failwith "Raising an exception!";
+     if uncaught_exception then failwith "Raising an exception!";
+     if err_raise then Err.raise ~loc [ Pp.text "Hello [Err.raise]!" ];
      let msg = Err.create ~loc [ Pp.textf "%s message" (Err.Level.to_string level) ] in
      Err.emit msg ~level)
 ;;

--- a/lib/err/test/cram/run.t
+++ b/lib/err/test/cram/run.t
@@ -111,3 +111,11 @@ The same must be true for errors that are raised via `Err.raise`.
   > --verbosity=quiet \
   > --err-raise
   [123]
+
+And internal errors too.
+
+  $ ./main.exe write --file file --line 1 --pos-bol 0 \
+  > --pos-cnum 0 --length 5 \
+  > --verbosity=quiet \
+  > --uncaught-exception
+  [125]

--- a/lib/err/test/cram/run.t
+++ b/lib/err/test/cram/run.t
@@ -60,8 +60,17 @@ Exercising the error handling from the command line.
 
   $ ./main.exe write --file file --line 1 --pos-bol 0 \
   > --pos-cnum 0 --length 5 \
-  > --raise 2>&1 | head -n 1
+  > --uncaught-exception 2>&1 | head -n 1
   Internal Error: Failure("Raising an exception!")
+
+  $ ./main.exe write --file file --line 1 --pos-bol 0 \
+  > --pos-cnum 0 --length 5 \
+  > --err-raise
+  File "file", line 1, characters 0-5:
+  1 | Hello World
+      ^^^^^
+  Error: Hello [Err.raise]!
+  [123]
 
 Logs and Fmt options.
 
@@ -93,4 +102,12 @@ correctly accounted for in the error count.
   > --pos-cnum 0 --length 5 \
   > --level=error \
   > --verbosity=quiet
+  [123]
+
+The same must be true for errors that are raised via `Err.raise`.
+
+  $ ./main.exe write --file file --line 1 --pos-bol 0 \
+  > --pos-cnum 0 --length 5 \
+  > --verbosity=quiet \
+  > --err-raise
   [123]

--- a/lib/err/test/test__log_level.ml
+++ b/lib/err/test/test__log_level.ml
@@ -227,8 +227,8 @@ let%expect_test "log levels" =
 ;;
 
 let%expect_test "error when quiet" =
-  (* When the logs level is set to [quiet] errors are not shown, and not
-     accounted for in the [error_count] and [had_errors]. *)
+  (* When the logs level is set to [quiet] errors are not shown, but they are
+     accounted for by [error_count] and [had_errors]. *)
   Err.For_test.protect (fun () ->
     let set_log_level log_level =
       Log_cli.setup_config ~config:(Log_cli.Config.create ~log_level ())
@@ -242,8 +242,8 @@ let%expect_test "error when quiet" =
 ;;
 
 let%expect_test "raise when quiet" =
-  (* When the logs level is set to [quiet], raising errors will be non impacted
-     and behaves as usual. *)
+  (* When the logs level is set to [quiet], raised errors will not be shown, but
+     this does not impact the exit code, nor the exception raised. *)
   Err.For_test.protect (fun () ->
     let set_log_level log_level =
       Log_cli.setup_config ~config:(Log_cli.Config.create ~log_level ())
@@ -252,7 +252,6 @@ let%expect_test "raise when quiet" =
     Err.raise [ Pp.text "Hello Exn1" ]);
   [%expect
     {|
-    Error: Hello Exn1
     [123]
     |}];
   print_s [%sexp (Err.had_errors () : bool)];


### PR DESCRIPTION
For consistency with errors printed via `Err.emit`, do not print raised errors and exceptions when in quiet mode. However, keep the result of the execution (via exit-code) the same, in accordance to recent changes regarding this point.