### PR TITLE
Testing build warnings with Ocaml 4.14 flambda (do not merge)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,5 @@
 (lang dune 3.20)
+
 ;; CR mbarbin: I'm testing [https://github.com/ocaml/dune/pull/11866] which
 ;; requires bumping the dune language.
 
@@ -19,7 +20,12 @@
 
 (using mdx 0.4)
 
-(implicit_transitive_deps false-if-hidden-includes-supported)
+;; (implicit_transitive_deps false-if-hidden-includes-supported)
+
+;; (implicit_transitive_deps true)
+
+(implicit_transitive_deps false)
+
 ;; CR mbarbin: Trying without this to see whether this impacts the warning.
 ;;
 ;; Edit: I'm testing with [https://github.com/ocaml/dune/pull/11866].

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,6 @@
-(lang dune 3.17)
+(lang dune 3.20)
+;; CR mbarbin: I'm testing [https://github.com/ocaml/dune/pull/11866] which
+;; requires bumping the dune language.
 
 (name pplumbing)
 
@@ -17,8 +19,10 @@
 
 (using mdx 0.4)
 
+(implicit_transitive_deps false-if-hidden-includes-supported)
 ;; CR mbarbin: Trying without this to see whether this impacts the warning.
-;; (implicit_transitive_deps false)
+;;
+;; Edit: I'm testing with [https://github.com/ocaml/dune/pull/11866].
 
 (package
  (name pplumbing)

--- a/dune-project
+++ b/dune-project
@@ -22,9 +22,9 @@
 
 ;; (implicit_transitive_deps false-if-hidden-includes-supported)
 
-;; (implicit_transitive_deps true)
+(implicit_transitive_deps true)
 
-(implicit_transitive_deps false)
+;; (implicit_transitive_deps false)
 
 ;; CR mbarbin: Trying without this to see whether this impacts the warning.
 ;;

--- a/dune-project
+++ b/dune-project
@@ -17,7 +17,8 @@
 
 (using mdx 0.4)
 
-(implicit_transitive_deps false)
+;; CR mbarbin: Trying without this to see whether this impacts the warning.
+;; (implicit_transitive_deps false)
 
 (package
  (name pplumbing)

--- a/dune-project
+++ b/dune-project
@@ -20,9 +20,9 @@
 
 (using mdx 0.4)
 
-;; (implicit_transitive_deps false-if-hidden-includes-supported)
+(implicit_transitive_deps false-if-hidden-includes-supported)
 
-(implicit_transitive_deps true)
+;; (implicit_transitive_deps true)
 
 ;; (implicit_transitive_deps false)
 

--- a/pplumbing.opam
+++ b/pplumbing.opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/mbarbin/pplumbing"
 doc: "https://mbarbin.github.io/pplumbing/"
 bug-reports: "https://github.com/mbarbin/pplumbing/issues"
 depends: [
-  "dune" {>= "3.17"}
+  "dune" {>= "3.20"}
   "ocaml" {>= "4.14"}
   "cmdlang" {>= "0.0.9"}
   "cmdlang-to-cmdliner" {>= "0.0.9"}


### PR DESCRIPTION
This is a draft PR to experiment with dune options as it relates to `(implicit_transitive_deps _)`.